### PR TITLE
Use parse_qs instead of hand-rolled parsing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: +./.github/codeql/SqlInjectionMod.ql
+        # queries: security-extended
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above

--- a/dsvw.py
+++ b/dsvw.py
@@ -23,7 +23,7 @@ def init():
 class ReqHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         path, query = self.path.split('?', 1) if '?' in self.path else (self.path, "")
-        code, content, params, cursor = http.client.OK, HTML_PREFIX, dict((match.group("parameter"), urllib.parse.unquote(','.join(re.findall(r"(?:\A|[?&])%s=([^&]+)" % match.group("parameter"), query)))) for match in re.finditer(r"((\A|[?&])(?P<parameter>[\w\[\]]+)=)([^&]+)", query)), connection.cursor()
+        code, content, params, cursor = http.client.OK, HTML_PREFIX, dict(parse_qs(query)), connection.cursor()
         try:
             if path == '/':
                 if "id" in params:

--- a/dsvw.py
+++ b/dsvw.py
@@ -23,7 +23,7 @@ def init():
 class ReqHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         path, query = self.path.split('?', 1) if '?' in self.path else (self.path, "")
-        code, content, params, cursor = http.client.OK, HTML_PREFIX, parse_qs(query), connection.cursor()
+        code, content, params, cursor = http.client.OK, HTML_PREFIX, urllib.parse.parse_qs(query), connection.cursor()
         try:
             if path == '/':
                 if "id" in params:

--- a/dsvw.py
+++ b/dsvw.py
@@ -23,7 +23,7 @@ def init():
 class ReqHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         path, query = self.path.split('?', 1) if '?' in self.path else (self.path, "")
-        code, content, params, cursor = http.client.OK, HTML_PREFIX, dict(parse_qs(query)), connection.cursor()
+        code, content, params, cursor = http.client.OK, HTML_PREFIX, parse_qs(query), connection.cursor()
         try:
             if path == '/':
                 if "id" in params:


### PR DESCRIPTION
Change to parsing the `query` into `params` using standard `parse_qs` out of `urllib.parse`